### PR TITLE
Fix class of *Index pfc_calendar field

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@
 - NEW: `FXRates()` and `ZeroCurves()` allows you to create tables of FX rates and zero curves for use in pricing.
 - NEW: `PricingEnv()` allows you to wrap up `FXRates` and `ZeroCurves` into a single container with `pick()` allowing you select particular pricing elements.
 - NEW: `build_fx_rates()`, `build_zero_curves()` and `build_pricing_env()` to enable the creation of associated objects using example market data
+- FIXED: `pfc_calendar` field of `IborIndex` and `CashIndex` fields must now inherit from `Calendar` (#8). CashIndex and IborIndex constructors now support this.
 - Internal change to class structure
 
 # Version 0.2.0

--- a/R/indices-class.R
+++ b/R/indices-class.R
@@ -78,6 +78,7 @@ validate_IborIndex <- function(x) {
     lubridate::is.period(x$tenor),
     lubridate::is.period(x$spot_lag),
     fmdates::is.JointCalendar(x$calendar),
+    fmdates::is.JointCalendar(x$pfc_calendar),
     fmdates::is_valid_day_basis(x$day_basis),
     fmdates::is_valid_bdc(x$day_convention),
     assertthat::is.flag(x$is_eom)
@@ -91,6 +92,7 @@ validate_CashIndex <- function(x) {
     is.Currency(x$currency),
     lubridate::is.period(x$spot_lag),
     fmdates::is.JointCalendar(x$calendar),
+    fmdates::is.JointCalendar(x$pfc_calendar),
     fmdates::is_valid_day_basis(x$day_basis),
     fmdates::is_valid_bdc(x$day_convention)
   )

--- a/R/indices-class.R
+++ b/R/indices-class.R
@@ -28,7 +28,7 @@ IborIndex <- function(name, currency, tenor, spot_lag, calendar, day_basis,
   day_convention, is_eom) {
 
   x <- new_Index("Ibor", name = name, currency = currency, tenor = tenor,
-    spot_lag = spot_lag, calendar = calendar, pfc_calendar = locale(calendar),
+    spot_lag = spot_lag, calendar = calendar, pfc_calendar = currency$calendar,
     day_basis = day_basis, day_convention = day_convention, is_eom = is_eom
   )
 
@@ -57,7 +57,7 @@ CashIndex <- function(name, currency, spot_lag, calendar, day_basis,
 
   x <- new_Index("Cash", name = name, currency = currency,
     tenor = lubridate::days(1), spot_lag = spot_lag, calendar = calendar,
-    pfc_calendar = locale(calendar), day_basis = day_basis,
+    pfc_calendar = currency$calendar, day_basis = day_basis,
     day_convention = day_convention, is_eom = FALSE
   )
 


### PR DESCRIPTION
Fixes #8. `pfc_calendar` field of `IborIndex` and `CashIndex` fields must now inherit from `Calendar`. CashIndex and IborIndex constructors now support this.
