### PR TITLE
Fix interpolation docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: fmbasics
 Title: Financial Market Building Blocks
-Version: 0.3.0
+Version: 0.3.99
 Authors@R: person("Imanuel", "Costigan", email = "i.costigan@me.com", 
                   role = c("aut", "cre"))
 Description: Implements basic financial market objects like currencies, currency

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,4 +29,4 @@ VignetteBuilder: knitr
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+# Version 0.3.99
+
+IMPROVED:
+
+- Rebuilt documentation using newer version of `roxygen2`
+- `ZeroCurve` documentation explicitly describes the various interpolation methods available (#20)
+
+
 # Version 0.3.0
 
 NEW:

--- a/R/zero-curve-class.R
+++ b/R/zero-curve-class.R
@@ -19,10 +19,17 @@
 #' rates. When the effect of coupons on yields are stripped away, one has a
 #' zero-coupon yield curve.
 #'
+#' @section Interpolation schemes:
+#'
 #' The following interpolation schemes are supported by `ZeroCurve`:
-#' `ConstantInterpolation`, `LinearInterpolation`, `LogDFInterpolation` and
-#' `CubicInterpolation`. Points outside the calibration region use constant
-#' extrapolation on the zero rate.
+#'
+#' * `ConstantInterpolation`: constant interpolation on zero rates
+#' * `LinearInterpolation`: linear interpolation on zero rates
+#' * `LogDFInterpolation`: linear interpolation on log discount factors or
+#'    constant on forward rates
+#' * `CubicInterpolation`: natural cubic spline on zero rates
+#'
+#' Points outside the calibration region use constant extrapolation on zero rates.
 #'
 #' @param discount_factors a [`DiscountFactor`] object. These are converted to
 #'   continuously compounded zero coupon interest rates with an `act/365` day

--- a/man/CashFlow.Rd
+++ b/man/CashFlow.Rd
@@ -30,3 +30,4 @@ Other money functions: \code{\link{MultiCurrencyMoney}},
   \code{\link{is.MultiCurrencyMoney}},
   \code{\link{is.SingleCurrencyMoney}}
 }
+\concept{money functions}

--- a/man/Currency.Rd
+++ b/man/Currency.Rd
@@ -7,7 +7,7 @@
 Currency(iso, calendar)
 }
 \arguments{
-\item{iso}{a three letter code representing the currency (see \href{https://en.wikipedia.org/wiki/ISO_4217}{ISO4217})}
+\item{iso}{a three letter code representing the currency (see \href{https://en.wikipedia.org/wiki/ISO_4217}{ISO 4217})}
 
 \item{calendar}{a \link[fmdates:JointCalendar]{JointCalendar}}
 }

--- a/man/CurrencyConstructors.Rd
+++ b/man/CurrencyConstructors.Rd
@@ -55,3 +55,4 @@ AUD()
 Other constructors: \code{\link{CurrencyPairConstructors}},
   \code{\link{iborindices}}, \code{\link{oniaindices}}
 }
+\concept{constructors}

--- a/man/CurrencyPairConstructors.Rd
+++ b/man/CurrencyPairConstructors.Rd
@@ -44,8 +44,7 @@ EURNOK()
 USDNOK()
 }
 \description{
-These handy \code{CurrencyPair} constructors use their \link[=CurrencyConstructors]{single currency
-counterparts} in the obvious fashion.
+These handy \code{CurrencyPair} constructors use their \link[=CurrencyConstructors]{single currency counterparts} in the obvious fashion.
 }
 \examples{
 AUDUSD()
@@ -54,3 +53,4 @@ AUDUSD()
 Other constructors: \code{\link{CurrencyConstructors}},
   \code{\link{iborindices}}, \code{\link{oniaindices}}
 }
+\concept{constructors}

--- a/man/IborIndex.Rd
+++ b/man/IborIndex.Rd
@@ -4,8 +4,8 @@
 \alias{IborIndex}
 \title{IborIndex class}
 \usage{
-IborIndex(name, currency, tenor, spot_lag, calendar, day_basis, day_convention,
-  is_eom)
+IborIndex(name, currency, tenor, spot_lag, calendar, day_basis,
+  day_convention, is_eom)
 }
 \arguments{
 \item{name}{the name of the index as a string}

--- a/man/MultiCurrencyMoney.Rd
+++ b/man/MultiCurrencyMoney.Rd
@@ -33,3 +33,4 @@ Other money functions: \code{\link{CashFlow}},
   \code{\link{is.MultiCurrencyMoney}},
   \code{\link{is.SingleCurrencyMoney}}
 }
+\concept{money functions}

--- a/man/SingleCurrencyMoney.Rd
+++ b/man/SingleCurrencyMoney.Rd
@@ -31,3 +31,4 @@ Other money functions: \code{\link{CashFlow}},
   \code{\link{is.MultiCurrencyMoney}},
   \code{\link{is.SingleCurrencyMoney}}
 }
+\concept{money functions}

--- a/man/ZeroCurve.Rd
+++ b/man/ZeroCurve.Rd
@@ -34,12 +34,22 @@ traders, and are commonly plotted on a graph. More formal mathematical
 descriptions of this relation are often called the term structure of interest
 rates. When the effect of coupons on yields are stripped away, one has a
 zero-coupon yield curve.
+}
+\section{Interpolation schemes}{
+
 
 The following interpolation schemes are supported by \code{ZeroCurve}:
-\code{ConstantInterpolation}, \code{LinearInterpolation}, \code{LogDFInterpolation} and
-\code{CubicInterpolation}. Points outside the calibration region use constant
-extrapolation on the zero rate.
+\itemize{
+\item \code{ConstantInterpolation}: constant interpolation on zero rates
+\item \code{LinearInterpolation}: linear interpolation on zero rates
+\item \code{LogDFInterpolation}: linear interpolation on log discount factors or
+constant on forward rates
+\item \code{CubicInterpolation}: natural cubic spline on zero rates
 }
+
+Points outside the calibration region use constant extrapolation on zero rates.
+}
+
 \examples{
 build_zero_curve()
 }

--- a/man/build_zero_curve.Rd
+++ b/man/build_zero_curve.Rd
@@ -19,3 +19,4 @@ This creates a \code{\link{ZeroCurve}} object from the example data set
 \examples{
 build_zero_curve(LogDFInterpolation())
 }
+\concept{build object helpers}

--- a/man/iborindices.Rd
+++ b/man/iborindices.Rd
@@ -12,17 +12,7 @@
 \alias{CHFLIBOR}
 \alias{HKDHIBOR}
 \alias{NOKNIBOR}
-\alias{AUDBBSW}
 \alias{AUDBBSW1b}
-\alias{EURIBOR}
-\alias{GBPLIBOR}
-\alias{JPYLIBOR}
-\alias{JPYTIBOR}
-\alias{NZDBKBM}
-\alias{USDLIBOR}
-\alias{CHFLIBOR}
-\alias{HKDHIBOR}
-\alias{NOKNIBOR}
 \title{Standard IBOR}
 \usage{
 AUDBBSW(tenor)
@@ -91,3 +81,4 @@ Other constructors: \code{\link{CurrencyConstructors}},
   \code{\link{CurrencyPairConstructors}},
   \code{\link{oniaindices}}
 }
+\concept{constructors}

--- a/man/interpolate.Rd
+++ b/man/interpolate.Rd
@@ -22,3 +22,4 @@ Other interpolate functions: \code{\link{interpolate.ZeroCurve}},
   \code{\link{interpolate_dfs}},
   \code{\link{interpolate_zeros}}
 }
+\concept{interpolate functions}

--- a/man/interpolate.ZeroCurve.Rd
+++ b/man/interpolate.ZeroCurve.Rd
@@ -34,3 +34,4 @@ Other interpolate functions: \code{\link{interpolate_dfs}},
   \code{\link{interpolate_zeros}},
   \code{\link{interpolate}}
 }
+\concept{interpolate functions}

--- a/man/interpolate_dfs.Rd
+++ b/man/interpolate_dfs.Rd
@@ -3,7 +3,6 @@
 \name{interpolate_dfs}
 \alias{interpolate_dfs}
 \alias{interpolate_fwds}
-\alias{interpolate_fwds}
 \alias{interpolate_fwds.ZeroCurve}
 \alias{interpolate_dfs.ZeroCurve}
 \title{Interpolate forward rates and discount factors}
@@ -40,3 +39,4 @@ Other interpolate functions: \code{\link{interpolate.ZeroCurve}},
   \code{\link{interpolate_zeros}},
   \code{\link{interpolate}}
 }
+\concept{interpolate functions}

--- a/man/interpolate_zeros.Rd
+++ b/man/interpolate_zeros.Rd
@@ -36,3 +36,4 @@ other object that contains such an object.
 Other interpolate functions: \code{\link{interpolate.ZeroCurve}},
   \code{\link{interpolate_dfs}}, \code{\link{interpolate}}
 }
+\concept{interpolate functions}

--- a/man/is.CashFlow.Rd
+++ b/man/is.CashFlow.Rd
@@ -26,3 +26,4 @@ Other money functions: \code{\link{CashFlow}},
   \code{\link{is.MultiCurrencyMoney}},
   \code{\link{is.SingleCurrencyMoney}}
 }
+\concept{money functions}

--- a/man/is.MultiCurrencyMoney.Rd
+++ b/man/is.MultiCurrencyMoney.Rd
@@ -25,3 +25,4 @@ Other money functions: \code{\link{CashFlow}},
   \code{\link{is.CashFlow}},
   \code{\link{is.SingleCurrencyMoney}}
 }
+\concept{money functions}

--- a/man/is.SingleCurrencyMoney.Rd
+++ b/man/is.SingleCurrencyMoney.Rd
@@ -25,3 +25,4 @@ Other money functions: \code{\link{CashFlow}},
   \code{\link{is.CashFlow}},
   \code{\link{is.MultiCurrencyMoney}}
 }
+\concept{money functions}

--- a/man/oniaindices.Rd
+++ b/man/oniaindices.Rd
@@ -10,14 +10,6 @@
 \alias{FedFunds}
 \alias{CHFTOIS}
 \alias{HONIX}
-\alias{AONIA}
-\alias{EONIA}
-\alias{SONIA}
-\alias{TONAR}
-\alias{NZIONA}
-\alias{FedFunds}
-\alias{CHFTOIS}
-\alias{HONIX}
 \title{Standard ONIA}
 \usage{
 AONIA()
@@ -75,3 +67,4 @@ Other constructors: \code{\link{CurrencyConstructors}},
   \code{\link{CurrencyPairConstructors}},
   \code{\link{iborindices}}
 }
+\concept{constructors}


### PR DESCRIPTION
Fixes #20. Changes proposed:

- Upgrade version of roxygen2 used to create Rd files
- Explicitly describe various `ZeroCurve` interpolation docs
